### PR TITLE
Fixed get duration crash.

### DIFF
--- a/WKYTPlayerView/WKYTPlayerView.m
+++ b/WKYTPlayerView/WKYTPlayerView.m
@@ -381,7 +381,12 @@ NSString static *const kWKYTPlayerSyndicationRegexPattern = @"^https://tpc.googl
             if (error) {
                 completionHandler(0, error);
             } else {
-                completionHandler([response doubleValue], nil);
+                if (response != (id) [NSNull null]) {
+                    completionHandler([response doubleValue], nil);
+                }
+                else {
+                    completionHandler(0, nil);
+                }
             }
         }
     }];


### PR DESCRIPTION
When the youtube video is live, "getDuration" method always crash.
The cause of this crash is that the response is null.
I added null check before get doubleValue.
 