### PR TITLE
Fix crash in getPlaylist: on iOS12 where the response from the javasc…

### DIFF
--- a/WKYTPlayerView/WKYTPlayerView.m
+++ b/WKYTPlayerView/WKYTPlayerView.m
@@ -427,13 +427,28 @@ NSString static *const kWKYTPlayerSyndicationRegexPattern = @"^https://tpc.googl
             if (error) {
                 completionHandler(nil, error);
             } else {
-                NSData *playlistData = [response dataUsingEncoding:NSUTF8StringEncoding];
-                NSError *jsonDeserializationError;
-                NSArray *videoIds = [NSJSONSerialization JSONObjectWithData:playlistData
-                                                                    options:kNilOptions
-                                                                      error:&jsonDeserializationError];
-                if (jsonDeserializationError) {
-                    completionHandler(nil, jsonDeserializationError);
+
+                if ([response isKindOfClass:[NSNull class]]) {
+                    completionHandler(nil, nil);
+                    return;
+                }
+
+                NSArray *videoIds;
+
+                if ([response isKindOfClass:[NSArray class]])
+                {
+                    videoIds = (NSArray *)response;
+                }
+                else
+                {
+                    NSData *playlistData = [response dataUsingEncoding:NSUTF8StringEncoding];
+                    NSError *jsonDeserializationError;
+                    videoIds = [NSJSONSerialization JSONObjectWithData:playlistData
+                                                                        options:kNilOptions
+                                                                        error:&jsonDeserializationError];
+                    if (jsonDeserializationError) {
+                        completionHandler(nil, jsonDeserializationError);
+                    }
                 }
 
                 completionHandler(videoIds, nil);

--- a/WKYTPlayerView/WKYTPlayerView.m
+++ b/WKYTPlayerView/WKYTPlayerView.m
@@ -333,6 +333,10 @@ NSString static *const kWKYTPlayerSyndicationRegexPattern = @"^https://tpc.googl
             if (error) {
                 completionHandler(kWKYTPlayerStateUnknown, error);
             } else {
+                if ([response isKindOfClass: [NSNumber class]]) {
+                    NSNumber *value = (NSNumber *)response;
+                    response = [value stringValue];
+                }
                 completionHandler([WKYTPlayerView playerStateForString:response], nil);
             }
         }


### PR DESCRIPTION
…ript evaluation was of type NSArray as opposed to NSString.

This was throwing an exception when sending message dataUsingEncoding: on a type NSArray.