### PR TITLE
Fix invalid framework bundle for subclass

### DIFF
--- a/WKYTPlayerView/WKYTPlayerView.m
+++ b/WKYTPlayerView/WKYTPlayerView.m
@@ -1084,7 +1084,7 @@ NSString static *const kWKYTPlayerSyndicationRegexPattern = @"^https://tpc.googl
     static NSBundle* frameworkBundle = nil;
     static dispatch_once_t predicate;
     dispatch_once(&predicate, ^{
-        NSString* mainBundlePath = [[NSBundle bundleForClass:[self class]] resourcePath];
+        NSString* mainBundlePath = [[NSBundle bundleForClass:[WKYTPlayerView class]] resourcePath];
         NSString* frameworkBundlePath = [mainBundlePath stringByAppendingPathComponent:@"WKYTPlayerView.bundle"];
         frameworkBundle = [NSBundle bundleWithPath:frameworkBundlePath];
     });


### PR DESCRIPTION
If WKYTPlayerView is subclassed outside of the pod, the bundleForClass will point to the wrong bundle. We want this bundle to be fixed to the project bundle, holding the YTPlayerView-iframe-player.html.