### PR TITLE
[FIX] fix share button /watch later button action

### DIFF
--- a/WKYTPlayerView/WKYTPlayerView.h
+++ b/WKYTPlayerView/WKYTPlayerView.h
@@ -146,7 +146,7 @@ typedef NS_ENUM(NSInteger, WKYTPlayerError) {
  * WKYTPlayerView::loadWithPlaylistId: or their variants to set the video or playlist
  * to populate the view with.
  */
-@interface WKYTPlayerView : UIView<WKNavigationDelegate>
+@interface WKYTPlayerView : UIView<WKNavigationDelegate, WKUIDelegate>
 
 @property(nonatomic, strong, nullable, readonly) WKWebView *webView;
 

--- a/WKYTPlayerView/WKYTPlayerView.m
+++ b/WKYTPlayerView/WKYTPlayerView.m
@@ -575,6 +575,14 @@ NSString static *const kWKYTPlayerSyndicationRegexPattern = @"^https://tpc.googl
     }
 }
 
+- (WKWebView *)webView:(WKWebView *)webView createWebViewWithConfiguration:(WKWebViewConfiguration *)configuration forNavigationAction:(WKNavigationAction *)navigationAction windowFeatures:(WKWindowFeatures *)windowFeatures {
+    if (!navigationAction.targetFrame.isMainFrame) {
+        //  open link with target="_blank" in the same webView
+        [webView loadRequest:navigationAction.request];
+    }
+    return nil;
+}
+
 /**
  * Convert a quality value from NSString to the typed enum value.
  *
@@ -945,6 +953,7 @@ NSString static *const kWKYTPlayerSyndicationRegexPattern = @"^https://tpc.googl
     NSString *embedHTML = [NSString stringWithFormat:embedHTMLTemplate, playerVarsJsonString];
     [self.webView loadHTMLString:embedHTML baseURL: self.originURL];
     self.webView.navigationDelegate = self;
+    self.webView.UIDelegate = self;
     
     if ([self.delegate respondsToSelector:@selector(playerViewPreferredInitialLoadingView:)]) {
         UIView *initialLoadingView = [self.delegate playerViewPreferredInitialLoadingView:self];


### PR DESCRIPTION
When you initialize a player with origin in player params, buttons will not work properly. So we need to implement WKUIDelegate to handle these button with target=“_blank”.