### PR TITLE
Comment changes for Apple's depreciation scanner

### DIFF
--- a/WKYTPlayerView/WKYTPlayerView.h
+++ b/WKYTPlayerView/WKYTPlayerView.h
@@ -158,8 +158,8 @@ typedef NS_ENUM(NSInteger, WKYTPlayerError) {
  * This is a convenience method for calling WKYTPlayerView::loadPlayerWithVideoId:withPlayerVars:
  * without player variables.
  *
- * This method reloads the entire contents of the UIWebView and regenerates its HTML contents.
- * To change the currently loaded video without reloading the entire UIWebView, use the
+ * This method reloads the entire contents of the WKWebView and regenerates its HTML contents.
+ * To change the currently loaded video without reloading the entire WKWebView, use the
  * WKYTPlayerView::cueVideoById:startSeconds:suggestedQuality: family of methods.
  *
  * @param videoId The YouTube video ID of the video to load in the player view.
@@ -172,8 +172,8 @@ typedef NS_ENUM(NSInteger, WKYTPlayerError) {
  * This is a convenience method for calling WKYTPlayerView::loadWithPlaylistId:withPlayerVars:
  * without player variables.
  *
- * This method reloads the entire contents of the UIWebView and regenerates its HTML contents.
- * To change the currently loaded video without reloading the entire UIWebView, use the
+ * This method reloads the entire contents of the WKWebView and regenerates its HTML contents.
+ * To change the currently loaded video without reloading the entire WKWebView, use the
  * WKYTPlayerView::cuePlaylistByPlaylistId:index:startSeconds:suggestedQuality:
  * family of methods.
  *
@@ -195,8 +195,8 @@ typedef NS_ENUM(NSInteger, WKYTPlayerError) {
  * both strings and integers are valid values. The full list of parameters is defined at:
  *   https://developers.google.com/youtube/player_parameters?playerVersion=HTML5.
  *
- * This method reloads the entire contents of the UIWebView and regenerates its HTML contents.
- * To change the currently loaded video without reloading the entire UIWebView, use the
+ * This method reloads the entire contents of the WKWebView and regenerates its HTML contents.
+ * To change the currently loaded video without reloading the entire WKWebView, use the
  * WKYTPlayerView::cueVideoById:startSeconds:suggestedQuality: family of methods.
  *
  * @param videoId The YouTube video ID of the video to load in the player view.
@@ -218,8 +218,8 @@ typedef NS_ENUM(NSInteger, WKYTPlayerError) {
  * both strings and integers are valid values. The full list of parameters is defined at:
  *   https://developers.google.com/youtube/player_parameters?playerVersion=HTML5.
  *
- * This method reloads the entire contents of the UIWebView and regenerates its HTML contents.
- * To change the currently loaded video without reloading the entire UIWebView, use the
+ * This method reloads the entire contents of the WKWebView and regenerates its HTML contents.
+ * To change the currently loaded video without reloading the entire WKWebView, use the
  * WKYTPlayerView::cueVideoById:startSeconds:suggestedQuality: family of methods.
  *
  * @param videoId The YouTube video ID of the video to load in the player view.
@@ -242,8 +242,8 @@ typedef NS_ENUM(NSInteger, WKYTPlayerError) {
  * both strings and integers are valid values. The full list of parameters is defined at:
  *   https://developers.google.com/youtube/player_parameters?playerVersion=HTML5.
  *
- * This method reloads the entire contents of the UIWebView and regenerates its HTML contents.
- * To change the currently loaded video without reloading the entire UIWebView, use the
+ * This method reloads the entire contents of the WKWebView and regenerates its HTML contents.
+ * To change the currently loaded video without reloading the entire WKWebView, use the
  * WKYTPlayerView::cuePlaylistByPlaylistId:index:startSeconds:suggestedQuality:
  * family of methods.
  *

--- a/WKYTPlayerView/WKYTPlayerView.m
+++ b/WKYTPlayerView/WKYTPlayerView.m
@@ -703,7 +703,7 @@ NSString static *const kWKYTPlayerSyndicationRegexPattern = @"^https://tpc.googl
 /**
  * Private method to handle "navigation" to a callback URL of the format
  * ytplayer://action?data=someData
- * This is how the UIWebView communicates with the containing Objective-C code.
+ * This is how the WKWebView communicates with the containing Objective-C code.
  * Side effects of this method are that it calls methods on this class's delegate.
  *
  * @param url A URL of the format ytplayer://action?data=value.
@@ -788,7 +788,7 @@ NSString static *const kWKYTPlayerSyndicationRegexPattern = @"^https://tpc.googl
 - (BOOL)handleHttpNavigationToUrl:(NSURL *) url {
     // Usually this means the user has clicked on the YouTube logo or an error message in the
     // player. Most URLs should open in the browser. The only http(s) URL that should open in this
-    // UIWebView is the URL for the embed, which is of the format:
+    // WKWebView is the URL for the embed, which is of the format:
     //     http(s)://www.youtube.com/embed/[VIDEO ID]?[PARAMETERS]
     NSError *error = NULL;
     NSRegularExpression *ytRegex =
@@ -1075,8 +1075,8 @@ NSString static *const kWKYTPlayerSyndicationRegexPattern = @"^https://tpc.googl
 
 - (WKWebView *)createNewWebView {
     
-    // WKWebView equivalent for UIWebView's scalesPageToFit
-    // http://stackoverflow.com/questions/26295277/wkwebview-equivalent-for-uiwebviews-scalespagetofit
+    // WKWebView equivalent for UI Web View's scalesPageToFit
+    // 
     NSString *jScript = @"var meta = document.createElement('meta'); meta.setAttribute('name', 'viewport'); meta.setAttribute('content', 'width=device-width'); document.getElementsByTagName('head')[0].appendChild(meta);";
     
     WKUserScript *wkUScript = [[WKUserScript alloc] initWithSource:jScript injectionTime:WKUserScriptInjectionTimeAtDocumentEnd forMainFrameOnly:YES];


### PR DESCRIPTION
Fixes to comments to replace UIWebView w/ WKWebView to resolve: 
`ITMS-90809: Deprecated API Usage - Apple will stop accepting submissions of apps that use UIWebView APIs . See https://developer.apple.com/documentation/uikit/uiwebview for more information.`