### PR TITLE
Strange iPad crash fix

### DIFF
--- a/WKYTPlayerView/WKYTPlayerView.m
+++ b/WKYTPlayerView/WKYTPlayerView.m
@@ -1097,7 +1097,7 @@ NSString static *const kWKYTPlayerSyndicationRegexPattern = @"^https://tpc.googl
     configuration.userContentController = wkUController;
     
     configuration.allowsInlineMediaPlayback = YES;
-    if ( UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad && [playsinline isEqualToNumber:@0]) {
+    if ([UIDevice currentDevice].userInterfaceIdiom == UIUserInterfaceIdiomPad && [playsinline isEqualToNumber:@0]) {
         configuration.allowsInlineMediaPlayback = NO; /* Device is iPad */
     }
 

--- a/WKYTPlayerView/WKYTPlayerView.m
+++ b/WKYTPlayerView/WKYTPlayerView.m
@@ -1097,7 +1097,7 @@ NSString static *const kWKYTPlayerSyndicationRegexPattern = @"^https://tpc.googl
     configuration.userContentController = wkUController;
     
     configuration.allowsInlineMediaPlayback = YES;
-    if ( [(NSString*)[UIDevice currentDevice].model hasPrefix:@"iPad"] && [playsinline isEqualToNumber:@0]) {
+    if ( UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad && [playsinline isEqualToNumber:@0]) {
         configuration.allowsInlineMediaPlayback = NO; /* Device is iPad */
     }
 


### PR DESCRIPTION
It was crashing in this line for iPad
`if ( [(NSString*)[UIDevice currentDevice].model hasPrefix:@"iPad"] && [playsinline isEqualToNumber:@0]) {`
so replaced with 
`if ( UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad && [playsinline isEqualToNumber:@0]) {`
now it works fine