### PR TITLE
fix: cocoapods and PrivacyInfo.xcprivacy

### DIFF
--- a/YoutubePlayer-in-WKWebView.podspec
+++ b/YoutubePlayer-in-WKWebView.podspec
@@ -32,6 +32,7 @@ Pod::Spec.new do |s|
   s.requires_arc = true
 
   s.source_files = 'WKYTPlayerView'
-  s.resources = ['WKYTPlayerView/WKYTPlayerView.bundle', 'WKYTPlayerView/PrivacyInfo.xcprivacy']
+  s.resources = ['WKYTPlayerView/WKYTPlayerView.bundle']
+  s.resource_bundles = { 'WKYTPlayerView' => 'WKYTPlayerView/PrivacyInfo.xcprivacy' }
 
 end


### PR DESCRIPTION
This one fixes #35 
There isn't much to add. Just tidies up the podspec to match the latest official specs